### PR TITLE
feat 💄 A0-54-VICTOR | enable the Register view with error handling

### DIFF
--- a/src/app/routes/app.routes.ts
+++ b/src/app/routes/app.routes.ts
@@ -3,11 +3,13 @@ import { TableTestComponent } from '@components/table/test'
 import { MyFeatureComponent } from '../components/modal/test';
 import { NavBarTest } from '../components/navBar/test';
 import { LoginView } from '@views/login/login.view';
+import { RegisterViewComponent } from '@views/register/register.view';
 import { LandingComponent } from '../views/landing/landing.component';
 
 export const routes: Routes = [
   { path: '', component: LandingComponent},
   { path: 'nav-bar', component: NavBarTest },
   { path: 'login', component: LoginView },
+  { path: 'register', component: RegisterViewComponent },
 ]
 

--- a/src/app/services/auth/register.service.ts
+++ b/src/app/services/auth/register.service.ts
@@ -1,0 +1,97 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError, map } from 'rxjs/operators';
+
+/**
+ * Interface para el payload de registro
+ */
+export interface RegisterPayload {
+  username: string;
+  email: string;
+  password_hash: string;
+  photo_profile_url?: string;
+}
+
+/**
+ * Interface para los datos del formulario de registro
+ */
+export interface RegisterFormData {
+  nombre: string;
+  primerApellido: string;
+  username: string;
+  email: string;
+  password: string;
+  confirmPassword: string;
+  photo_profile_url?: string;
+}
+
+/**
+ * Interface para la respuesta del registro
+ */
+export interface RegisterResponse {
+  success: boolean;
+  message: string;
+  data?: any;
+}
+
+/**
+ * Servicio para manejar el registro de usuarios
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class RegisterService {
+  private readonly http = inject(HttpClient);
+  private readonly apiUrl = '/api/register';
+
+  /**
+   * Registra un nuevo usuario
+   * @param payload Datos del usuario a registrar
+   * @returns Observable con la respuesta del servidor
+   */
+  register(payload: RegisterPayload): Observable<RegisterResponse> {
+    console.log('Enviando a:', this.apiUrl, 'Payload:', payload);
+    
+    return this.http.post<any>(this.apiUrl, payload)
+      .pipe(
+        map(response => {
+          console.log('Respuesta exitosa:', response);
+          return {
+            success: true,
+            message: 'Usuario registrado exitosamente',
+            data: response
+          };
+        }),
+        catchError(this.handleError)
+      );
+  }
+
+  /**
+   * Maneja los errores de las peticiones HTTP
+   * @param error Error de HTTP
+   * @returns Observable con el error formateado
+   */
+  private handleError = (error: HttpErrorResponse): Observable<RegisterResponse> => {
+    console.log('Error HTTP completo:', error);
+    console.log('Status:', error.status);
+    console.log('Error body:', error.error);
+    
+    let errorMessage = 'Error al registrar usuario';
+    
+    // Simplificar el manejo de errores
+    if (error.error && typeof error.error === 'string') {
+      errorMessage = error.error;
+    } else if (error.error && error.error.error) {
+      errorMessage = error.error.error;
+    } else if (error.message) {
+      errorMessage = error.message;
+    }
+
+    return throwError(() => ({
+      success: false,
+      message: errorMessage,
+      data: null
+    }));
+  };
+}

--- a/src/app/views/login/login.view.html
+++ b/src/app/views/login/login.view.html
@@ -19,6 +19,7 @@
           [text]="'Registrarse'"
           [buttonType]="'outline'"
           [type]="'button'"
+          (click)="navigateToRegister()"
         ></app-button>
       </div>
     </article>

--- a/src/app/views/login/login.view.ts
+++ b/src/app/views/login/login.view.ts
@@ -14,6 +14,10 @@ import { Alert } from '@components/alert/alert';
 export class LoginView {
   constructor(private alert: Alert) {}
 
+  navigateToRegister() {
+    window.location.href = '/register';
+  }
+
   async loginHandler(event: SubmitEvent) {
     event.preventDefault();
     const form = event.target as HTMLFormElement;

--- a/src/app/views/register/register.view.html
+++ b/src/app/views/register/register.view.html
@@ -1,0 +1,144 @@
+<main>
+  <section class="first-section">
+    <button (click)="navigateToLogin()">
+      <span class="material-symbols-outlined">arrow_back</span>
+    </button>
+    <article>
+      <svg width="70" height="70" viewBox="0 0 78 79" fill="none" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <rect width="70" height="70" fill="url(#pattern0_72_277)"/>
+        <defs>
+          <pattern id="pattern0_72_277" patternContentUnits="objectBoundingBox" width="1" height="1">
+            <use xlink:href="#image0_72_277" transform="matrix(0.004328 0 0 0.00424735 -0.374255 -0.36646)"/>
+          </pattern>
+        </defs>
+      </svg>
+      <h2>¿Ya tienes una cuenta?</h2>
+      <div class="button-container">
+        <app-button
+          [text]="'Iniciar Sesión'"
+          [buttonType]="'outline'"
+          [type]="'button'"
+          (buttonClick)="navigateToLogin()"
+        ></app-button>
+      </div>
+    </article>
+  </section>
+  <section class="register-form-container">
+    <form [formGroup]="registerForm" (ngSubmit)="onSubmit()">
+      
+      <!-- Alertas -->
+      @if (errorMessage) {
+        <div class="alert alert-error">
+          {{ errorMessage }}
+        </div>
+      }
+      
+      @if (successMessage) {
+        <div class="alert alert-success">
+          {{ successMessage }}
+        </div>
+      }
+
+      <h1>Crear Cuenta</h1>
+      
+      <app-input
+        [icon]="'person'"
+        [placeholder]="'Nombre'"
+        [type]="'text'"
+        [name]="'nombre'"
+        [value]="registerForm.get('nombre')?.value || ''"
+        (input)="onInputChange($event, 'nombre')"
+        [disabled]="isLoading"
+      ></app-input>
+      @if (hasFieldError('nombre')) {
+        <span class="error-message">{{ getFieldError('nombre') }}</span>
+      }
+      
+      <app-input
+        [icon]="'person'"
+        [placeholder]="'Primer apellido'"
+        [type]="'text'"
+        [name]="'primerApellido'"
+        [value]="registerForm.get('primerApellido')?.value || ''"
+        (input)="onInputChange($event, 'primerApellido')"
+        [disabled]="isLoading"
+      ></app-input>
+      @if (hasFieldError('primerApellido')) {
+        <span class="error-message">{{ getFieldError('primerApellido') }}</span>
+      }
+      
+      <app-input
+        [icon]="'person'"
+        [placeholder]="'Usuario'"
+        [type]="'text'"
+        [name]="'username'"
+        [value]="registerForm.get('username')?.value || ''"
+        (input)="onInputChange($event, 'username')"
+        [disabled]="isLoading"
+      ></app-input>
+      @if (hasFieldError('username')) {
+        <span class="error-message">{{ getFieldError('username') }}</span>
+      }
+      
+      <app-input
+        [icon]="'email'"
+        [placeholder]="'Correo Electrónico'"
+        [type]="'email'"
+        [name]="'email'"
+        [value]="registerForm.get('email')?.value || ''"
+        (input)="onInputChange($event, 'email')"
+        [disabled]="isLoading"
+      ></app-input>
+      @if (hasFieldError('email')) {
+        <span class="error-message">{{ getFieldError('email') }}</span>
+      }
+      
+      <app-input
+        [icon]="'lock'"
+        [placeholder]="'Contraseña'"
+        [type]="'password'"
+        [name]="'password'"
+        [value]="registerForm.get('password')?.value || ''"
+        (input)="onInputChange($event, 'password')"
+        [disabled]="isLoading"
+      ></app-input>
+      @if (hasFieldError('password')) {
+        <span class="error-message">{{ getFieldError('password') }}</span>
+      }
+      
+      <app-input
+        [icon]="'lock'"
+        [placeholder]="'Confirmar Contraseña'"
+        [type]="'password'"
+        [name]="'confirmPassword'"
+        [value]="registerForm.get('confirmPassword')?.value || ''"
+        (input)="onInputChange($event, 'confirmPassword')"
+        [disabled]="isLoading"
+      ></app-input>
+      @if (hasFieldError('confirmPassword')) {
+        <span class="error-message">{{ getFieldError('confirmPassword') }}</span>
+      }
+
+      <app-input
+        [icon]="'add_photo_alternate'"
+        [placeholder]="'URL Foto de Perfil (Opcional)'"
+        [type]="'url'"
+        [name]="'photo_profile_url'"
+        [value]="registerForm.get('photo_profile_url')?.value || ''"
+        (input)="onInputChange($event, 'photo_profile_url')"
+        [disabled]="isLoading"
+      ></app-input>
+
+      <app-button
+        [text]="isLoading ? 'Registrando...' : 'Continuar'"
+        [buttonType]="'primary'"
+        [type]="'submit'"
+        [disabled]="isLoading || !registerForm.valid"
+      ></app-button>
+      
+      <p class="privacy-text">
+        Al hacer clic en 'Continuar', usted acepta que sus datos personales sean utilizados de acuerdo con nuestra política de privacidad.
+      </p>
+    </form>
+  </section>
+</main>

--- a/src/app/views/register/register.view.scss
+++ b/src/app/views/register/register.view.scss
@@ -1,0 +1,240 @@
+@use '../../../styles.scss' as *;
+
+* {
+  margin: 0;
+}
+
+main {
+  display: flex;
+  flex-direction: row;
+}
+
+button {
+  position: absolute;
+  top: 1rem;
+  left: 1rem;
+  color: white;
+  background-color: transparent;
+  border: none;
+  
+  &:hover {
+    cursor: pointer;
+  }
+}
+
+svg {
+  width: 8rem;
+  height: 8rem;
+  fill: white;
+  object-fit: contain;
+  margin: 0 0 -.3rem .5rem;
+}
+
+.first-section {
+  width: 40%;
+  height: 100dvh;
+  background: linear-gradient(180deg, #72A6BB, #AECCD8);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.first-section article {
+  width: 70%;
+  height: 70%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+}
+
+h2 {
+  font-size: 28px;
+  font-family: 'Montserrat', sans-serif;
+  color: white;
+  font-weight: 600;
+}
+
+.button-container {
+  width: 75%;
+}
+
+.register-form-container {
+  width: 60%;
+  height: 100dvh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  overflow-y: auto;
+}
+
+form {
+  width: 50%;
+  height: auto;
+  max-height: 95%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  gap: 0.6rem;
+  overflow-y: visible;
+  padding: 0.5rem 0;
+}
+
+h1 {
+  font-size: 32px;
+  font-family: 'Montserrat', sans-serif;
+  color: #72A6BB;
+  font-weight: 650;
+  text-align: center;
+  margin-bottom: 0.3rem;
+}
+
+.alert {
+  padding: 8px;
+  border-radius: 8px;
+  margin-bottom: 10px;
+  font-size: 12px;
+  text-align: center;
+
+  &.alert-error {
+    background-color: #fee;
+    border: 1px solid #fcc;
+    color: #c33;
+  }
+
+  &.alert-success {
+    background-color: #efe;
+    border: 1px solid #cfc;
+    color: #3c3;
+  }
+}
+
+.error-message {
+  color: #e74c3c;
+  font-size: 10px;
+  margin-top: 2px;
+  display: block;
+}
+
+.privacy-text {
+  font-family: 'Inter', sans-serif;
+  font-weight: 700;
+  font-style: normal;
+  font-size: 11px;
+  line-height: 100%;
+  letter-spacing: 0%;
+  text-align: center;
+  color: #B6B6B6;
+  margin-top: 8px;
+  max-width: 515px;
+  width: 100%;
+  margin-left: auto;
+  margin-right: auto;
+  padding: 0 10px;
+}
+
+// Responsive
+@media (max-width: 1200px) {
+  form {
+    width: 60%;
+  }
+}
+
+@media (max-width: 1024px) {
+  main {
+    flex-direction: column;
+  }
+
+  .first-section {
+    width: 100%;
+    height: 35vh;
+    
+    article {
+      width: 80%;
+      height: 80%;
+    }
+  }
+
+  .register-form-container {
+    width: 100%;
+    height: 65vh;
+  }
+
+  form {
+    width: 70%;
+    max-height: 90%;
+    gap: 0.5rem;
+    padding: 0.5rem;
+  }
+
+  h1 {
+    font-size: 28px;
+    margin-bottom: 0.2rem;
+  }
+
+  .privacy-text {
+    font-size: 10px;
+    max-width: 90%;
+    margin-top: 6px;
+  }
+}
+
+@media (max-width: 768px) {
+  .first-section {
+    height: 30vh;
+  }
+
+  .register-form-container {
+    height: 70vh;
+    padding: 10px;
+  }
+
+  form {
+    width: 85%;
+    gap: 0.4rem;
+    padding: 0.3rem;
+  }
+
+  h1 {
+    font-size: 24px;
+  }
+
+  .privacy-text {
+    font-size: 9px;
+    max-width: 95%;
+  }
+
+  button {
+    top: 0.5rem;
+    left: 0.5rem;
+  }
+}
+
+@media (max-width: 480px) {
+  .first-section {
+    height: 25vh;
+  }
+
+  .register-form-container {
+    height: 75vh;
+  }
+
+  form {
+    width: 90%;
+    gap: 0.3rem;
+  }
+
+  h1 {
+    font-size: 20px;
+  }
+
+  h2 {
+    font-size: 22px;
+  }
+
+  .privacy-text {
+    font-size: 8px;
+    max-width: 100%;
+  }
+}

--- a/src/app/views/register/register.view.ts
+++ b/src/app/views/register/register.view.ts
@@ -1,41 +1,203 @@
-import { Component } from '@angular/core';
-import { NavBar } from '@components/navBar/navBar';
-import { register } from '@services/auth/auth.service';
+import { Component, inject, ChangeDetectorRef } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, FormGroup, Validators, ReactiveFormsModule } from '@angular/forms';
+import { Router } from '@angular/router';
+import { ButtonComponent } from '../../layouts/button/button.component';
+import { InputComponent } from '../../layouts/input/input.component';
+import { RegisterService, RegisterPayload } from '../../services/auth/register.service';
+import { ButtonType } from '../../layouts/button/button.enums';
 
 @Component({
-  selector: 'register-view',
-  imports: [],
-  template: `./register.view.html`
+  selector: 'app-register',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, ButtonComponent, InputComponent],
+  templateUrl: './register.view.html',
+  styleUrls: ['./register.view.scss']
 })
-export class RegisterView {
+export class RegisterViewComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly registerService = inject(RegisterService);
+  private readonly router = inject(Router);
+  private readonly cdr = inject(ChangeDetectorRef);
 
-  /*
-  async registerHandler(event: SubmitEvent) {
-    event.preventDefault();
-    const form = event.target as HTMLFormElement;
-    const formData = new FormData(form);
+  registerForm: FormGroup;
+  isLoading = false;
+  errorMessage = '';
+  successMessage = '';
+  fieldErrors: { [key: string]: string } = {};
 
-    const userRegisterPayload = {
-      username: formData.get('username') as string,
-      password: formData.get('password') as string,
-      email: formData.get('email') as string
-    };
+  // Enums para template
+  ButtonType = ButtonType;
 
-    try {
-      const result = await register(userRegisterPayload);
-      if (result instanceof Error) {
-        alert(result.message || 'Registration failed!');
-        return;
-      } else {
-        alert('Registration successful! You can now log in :).');
-        window.location.href = '/login';
-      }
-    } catch (error) {
-      console.error('Registration failed:', error);
-      const errorMessage = error instanceof Error ? error.message : 'An unexpected error occurred during registration.';
-      alert(`Registration failed: ${errorMessage}`);
+  constructor() {
+    this.registerForm = this.fb.group({
+      username: ['', [Validators.required, Validators.minLength(3)]],
+      email: ['', [Validators.required, Validators.email]],
+      password: ['', [Validators.required, Validators.minLength(8)]],
+      confirmPassword: ['', [Validators.required]],
+      photo_profile_url: [''] // Opcional
+    }, { validators: this.passwordMatchValidator });
+  }
+
+  /**
+   * Validador personalizado para confirmar que las contraseñas coincidan
+   */
+  passwordMatchValidator(form: FormGroup) {
+    const password = form.get('password');
+    const confirmPassword = form.get('confirmPassword');
+    
+    if (password && confirmPassword && password.value !== confirmPassword.value) {
+      confirmPassword.setErrors({ passwordMismatch: true });
+      return { passwordMismatch: true };
+    }
+    
+    if (confirmPassword?.hasError('passwordMismatch')) {
+      confirmPassword.setErrors(null);
+    }
+    
+    return null;
+  }
+
+  /**
+   * Maneja el envío del formulario de registro
+   */
+  onSubmit(): void {
+    if (this.registerForm.valid) {
+      this.isLoading = true;
+      this.errorMessage = '';
+      this.successMessage = '';
+
+      const payload: RegisterPayload = {
+        username: this.registerForm.get('username')?.value,
+        email: this.registerForm.get('email')?.value,
+        password_hash: this.registerForm.get('password')?.value,
+        photo_profile_url: this.registerForm.get('photo_profile_url')?.value || undefined
+      };
+
+      console.log('Enviando payload:', payload);
+
+      this.registerService.register(payload).subscribe({
+        next: (response) => {
+          setTimeout(() => {
+            this.isLoading = false;
+            if (response.success) {
+              this.successMessage = 'Usuario registrado exitosamente. Redirigiendo al login...';
+              this.cdr.detectChanges();
+              setTimeout(() => {
+                this.router.navigate(['/login']);
+              }, 2000);
+            } else {
+              this.errorMessage = response.message;
+              this.cdr.detectChanges();
+            }
+          }, 0);
+        },
+        error: (error) => {
+          console.error('Error en registro:', error);
+          
+          // Usar setTimeout para evitar ExpressionChangedAfterItHasBeenCheckedError
+          setTimeout(() => {
+            this.isLoading = false;
+            
+            // Limpiar errores anteriores
+            this.fieldErrors = {};
+            this.errorMessage = '';
+            
+            // Analizar el tipo de error y asignarlo al campo correspondiente
+            if (error.message) {
+              const errorText = error.message.toLowerCase();
+              
+              if (errorText.includes('username') || errorText.includes('usuario')) {
+                this.fieldErrors['username'] = error.message;
+              } else if (errorText.includes('email')) {
+                this.fieldErrors['email'] = error.message;
+              } else if (errorText.includes('password') || errorText.includes('contraseña')) {
+                this.fieldErrors['password'] = error.message;
+              } else {
+                // Error general
+                this.errorMessage = error.message;
+              }
+            } else {
+              this.errorMessage = 'Error al registrar usuario. Inténtalo de nuevo.';
+            }
+            
+            // Forzar detección de cambios
+            this.cdr.detectChanges();
+          }, 0);
+        }
+      });
+    } else {
+      this.markFormGroupTouched(this.registerForm);
     }
   }
-  */
 
+  /**
+   * Marca todos los campos del formulario como tocados para mostrar errores
+   */
+  private markFormGroupTouched(formGroup: FormGroup): void {
+    Object.keys(formGroup.controls).forEach(key => {
+      const control = formGroup.get(key);
+      control?.markAsTouched();
+    });
+  }
+
+  /**
+   * Obtiene el mensaje de error para un campo específico
+   */
+  getFieldError(fieldName: string): string {
+    // Primero verificar si hay errores del servidor
+    if (this.fieldErrors[fieldName]) {
+      return this.fieldErrors[fieldName];
+    }
+    
+    // Luego verificar errores de validación del formulario
+    const field = this.registerForm.get(fieldName);
+    if (field?.errors && field.touched) {
+      if (field.errors['required']) return `${fieldName} es requerido`;
+      if (field.errors['minlength']) return `${fieldName} debe tener al menos ${field.errors['minlength'].requiredLength} caracteres`;
+      if (field.errors['email']) return 'Email inválido';
+      if (field.errors['passwordMismatch']) return 'Las contraseñas no coinciden';
+    }
+    return '';
+  }
+
+  /**
+   * Verifica si un campo tiene errores
+   */
+  hasFieldError(fieldName: string): boolean {
+    // Verificar errores del servidor
+    if (this.fieldErrors[fieldName]) {
+      return true;
+    }
+    
+    // Verificar errores de validación del formulario
+    const field = this.registerForm.get(fieldName);
+    return !!(field?.errors && field.touched);
+  }
+
+  /**
+   * Navega al login
+   */
+  navigateToLogin(): void {
+    this.router.navigate(['/login']);
+  }
+
+  /**
+   * Maneja el cambio en los inputs del formulario
+   */
+  onInputChange(event: Event, fieldName: string): void {
+    const target = event.target as HTMLInputElement;
+    if (target) {
+      this.registerForm.get(fieldName)?.setValue(target.value);
+      
+      // Limpiar errores del servidor cuando el usuario empiece a escribir
+      // Usar setTimeout para evitar errores de change detection
+      if (this.fieldErrors[fieldName]) {
+        setTimeout(() => {
+          delete this.fieldErrors[fieldName];
+          this.cdr.detectChanges();
+        }, 0);
+      }
+    }
+  }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -32,6 +32,8 @@ html, body{
 // Variables de color
 $color-azul: #72A6BB;
 $color-azul-claro: #EAF2F5;
+$color-azul-oscuro: #2C3E50;
+$color-azul-principal: #72A6BB;
 $color-gris: #B6B6B6;
 $color-blanco: #FFFFFF;
 $color-negro: #000000;


### PR DESCRIPTION
Fully enabled the new Register view, including structured form validation and basic error handling logic.
Also added styling via register.view.scss based on figma file and created the corresponding service for user registration logic.

⚠️ There’s still a minor issue where the SVG image isn’t rendering properly — looks like a path or asset reference bug. Will investigate in the next patch.

✅ Progress:
– View is fully functional
– Register logic implemented via service
– Styled and responsive layout
– Error handling in place
– SVG not showing (bug logged)